### PR TITLE
Add Restkit to project configuration

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,3 +1,2 @@
-
 included:
     - ios_swift

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ git clone https://github.com/IBM/ar-resume-with-visual-recognition
 
 5. Go to `ios_swift` directory and open the project using `Xcode`.
 
-6. Create `BMSCredentials.plist` in the project and replace the credentials. The `plist` file looks like below:
+6. Create a `ResumeARStarter/BMSCredentials.plist` in the project and replace the credentials. The `plist` file looks like below:
 ```
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">

--- a/ios_swift/README.md
+++ b/ios_swift/README.md
@@ -18,7 +18,7 @@ IBM Cloud iOS Swift starter with Watson Visual Recognition and Core ML
 
 ### Summary
 
-Combining iOS face recognition using Vision API, classification using IBM Visual Recognition, and person identification using classified image and data, one can build an app to search faces and identify them. One of the use cases is to build a Augmented Reality based résumé using visual recognition.
+Combining iOS face recognition using Vision API, classification using IBM Visual Recognition, and person identification using classified image and data, one can build an app to search faces and identify them. One of the usecases is to build an Augmented Reality based résumé using visual recognition.
 
 This iOS app recognizes the face and presents you with an AR view that displays a résumé of the person in the camera view. The app classifies a face with Watson Visual Recognition and Core ML. The images are classified offline using a deep neural network that is trained by Visual Recognition.
 

--- a/ios_swift/ResumeARStarter.xcodeproj/project.pbxproj
+++ b/ios_swift/ResumeARStarter.xcodeproj/project.pbxproj
@@ -311,15 +311,18 @@
 				TargetAttributes = {
 					B4BF235A1FA2745D002906DD = {
 						CreatedOnToolsVersion = 9.0.1;
+						LastSwiftMigration = 1010;
 						ProvisioningStyle = Automatic;
 					};
 					B4BF23701FA2745D002906DD = {
 						CreatedOnToolsVersion = 9.0.1;
+						LastSwiftMigration = 1010;
 						ProvisioningStyle = Automatic;
 						TestTargetID = B4BF235A1FA2745D002906DD;
 					};
 					B4BF237B1FA2745D002906DD = {
 						CreatedOnToolsVersion = 9.0.1;
+						LastSwiftMigration = 1010;
 						ProvisioningStyle = Automatic;
 						TestTargetID = B4BF235A1FA2745D002906DD;
 					};
@@ -660,7 +663,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.codepattern.ResumeARStarter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -682,7 +685,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.codepattern.ResumeARStarter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -695,11 +698,11 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = PP64RT7P8Z;
-				INFOPLIST_FILE = ResumeARTests/Info.plist;
+				INFOPLIST_FILE = "$(SRCROOT)/ResumeARStarterTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.codepattern.ResumeARStarter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ResumeARStarter.app/ResumeARStarter";
 			};
@@ -713,11 +716,11 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = PP64RT7P8Z;
-				INFOPLIST_FILE = ResumeARTests/Info.plist;
+				INFOPLIST_FILE = "$(SRCROOT)/ResumeARStarterTests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.codepattern.ResumeARStarter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ResumeARStarter.app/ResumeARStarter";
 			};
@@ -730,11 +733,11 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = PP64RT7P8Z;
-				INFOPLIST_FILE = ResumeARUITests/Info.plist;
+				INFOPLIST_FILE = "$(SRCROOT)/ResumeARStarterUITests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.sg.ResumeARUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.codepattern.ResumeARUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = ResumeAR;
 			};
@@ -747,11 +750,11 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = PP64RT7P8Z;
-				INFOPLIST_FILE = ResumeARUITests/Info.plist;
+				INFOPLIST_FILE = "$(SRCROOT)/ResumeARStarterUITests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.sg.ResumeARUITests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.codepattern.ResumeARUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = ResumeAR;
 			};

--- a/ios_swift/ResumeARStarter.xcodeproj/project.pbxproj
+++ b/ios_swift/ResumeARStarter.xcodeproj/project.pbxproj
@@ -9,6 +9,9 @@
 /* Begin PBXBuildFile section */
 		3842A74647F25DB5BCED9FBB /* Pods_ResumeARStarterUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE1F8E97AE6145B021ACA986 /* Pods_ResumeARStarterUITests.framework */; };
 		A17C9566A3740B96AF43E648 /* Pods_ResumeARStarterTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7982E6C28D22700E9D94651E /* Pods_ResumeARStarterTests.framework */; };
+		AA27243821E93A90005B7878 /* RestKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA27243721E93A90005B7878 /* RestKit.framework */; };
+		AA27243921E93A90005B7878 /* RestKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = AA27243721E93A90005B7878 /* RestKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		AA27243B21E93E0B005B7878 /* BMSCredentials.plist in Resources */ = {isa = PBXBuildFile; fileRef = AA27243A21E93E0B005B7878 /* BMSCredentials.plist */; };
 		B424BCFA201F92DA00B18120 /* Cartfile in Resources */ = {isa = PBXBuildFile; fileRef = B424BCF9201F92DA00B18120 /* Cartfile */; };
 		B430E1231FE8448A00058C99 /* CloudantRESTCall.swift in Sources */ = {isa = PBXBuildFile; fileRef = B430E1221FE8448A00058C99 /* CloudantRESTCall.swift */; };
 		B43158AA209BA0BB004A0BF4 /* ScottDAngelo_1040670748.mlmodel in Sources */ = {isa = PBXBuildFile; fileRef = B43158A7209BA0BB004A0BF4 /* ScottDAngelo_1040670748.mlmodel */; };
@@ -61,6 +64,7 @@
 			dstSubfolderSpec = 10;
 			files = (
 				B4BE3DAF1FDB186C00268324 /* VisualRecognitionV3.framework in Embed Frameworks */,
+				AA27243921E93A90005B7878 /* RestKit.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -74,6 +78,8 @@
 		6B562D0F95F07D1705DB003A /* Pods-ResumeARStarterTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ResumeARStarterTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-ResumeARStarterTests/Pods-ResumeARStarterTests.release.xcconfig"; sourceTree = "<group>"; };
 		7735D50469CCC5D6A4C37810 /* Pods-ResumeARStarterTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ResumeARStarterTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ResumeARStarterTests/Pods-ResumeARStarterTests.debug.xcconfig"; sourceTree = "<group>"; };
 		7982E6C28D22700E9D94651E /* Pods_ResumeARStarterTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ResumeARStarterTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		AA27243721E93A90005B7878 /* RestKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RestKit.framework; path = Carthage/Build/iOS/RestKit.framework; sourceTree = "<group>"; };
+		AA27243A21E93E0B005B7878 /* BMSCredentials.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = BMSCredentials.plist; sourceTree = "<group>"; };
 		AE1F8E97AE6145B021ACA986 /* Pods_ResumeARStarterUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ResumeARStarterUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B424BCF9201F92DA00B18120 /* Cartfile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Cartfile; sourceTree = "<group>"; };
 		B430E1221FE8448A00058C99 /* CloudantRESTCall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudantRESTCall.swift; sourceTree = "<group>"; };
@@ -115,6 +121,7 @@
 			files = (
 				B4BE3DAE1FDB186C00268324 /* VisualRecognitionV3.framework in Frameworks */,
 				D77DFA937B3DBE328F4F3D53 /* Pods_ResumeARStarter.framework in Frameworks */,
+				AA27243821E93A90005B7878 /* RestKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -164,6 +171,7 @@
 		B4BF23521FA2745C002906DD = {
 			isa = PBXGroup;
 			children = (
+				AA27243721E93A90005B7878 /* RestKit.framework */,
 				B479E7612064643600786B47 /* Podfile */,
 				B424BCF9201F92DA00B18120 /* Cartfile */,
 				B4BF235D1FA2745D002906DD /* ResumeARStarter */,
@@ -188,6 +196,7 @@
 		B4BF235D1FA2745D002906DD /* ResumeARStarter */ = {
 			isa = PBXGroup;
 			children = (
+				AA27243A21E93E0B005B7878 /* BMSCredentials.plist */,
 				B43158A8209BA0BB004A0BF4 /* SanjeevGhimire_967590069.mlmodel */,
 				B43158A7209BA0BB004A0BF4 /* ScottDAngelo_1040670748.mlmodel */,
 				B43158A9209BA0BB004A0BF4 /* SteveMartinelli_2096165720.mlmodel */,
@@ -297,7 +306,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0900;
-				LastUpgradeCheck = 0900;
+				LastUpgradeCheck = 1010;
 				ORGANIZATIONNAME = "Sanjeev Ghimire";
 				TargetAttributes = {
 					B4BF235A1FA2745D002906DD = {
@@ -347,6 +356,7 @@
 				B4BF236B1FA2745D002906DD /* LaunchScreen.storyboard in Resources */,
 				B479E7532059A3C300786B47 /* facebook.png in Resources */,
 				B479E7522059A3C300786B47 /* linkedin.png in Resources */,
+				AA27243B21E93E0B005B7878 /* BMSCredentials.plist in Resources */,
 				B479E7622064643600786B47 /* Podfile in Resources */,
 				B4BF23681FA2745D002906DD /* Assets.xcassets in Resources */,
 				B4BF23661FA2745D002906DD /* Main.storyboard in Resources */,
@@ -414,6 +424,7 @@
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-ResumeARStarter/Pods-ResumeARStarter-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/PKHUD/PKHUD.framework",
+				"${BUILT_PRODUCTS_DIR}/RxAtomic/RxAtomic.framework",
 				"${BUILT_PRODUCTS_DIR}/RxCocoa/RxCocoa.framework",
 				"${BUILT_PRODUCTS_DIR}/RxSwift/RxSwift.framework",
 				"${BUILT_PRODUCTS_DIR}/SwiftyJSON/SwiftyJSON.framework",
@@ -421,6 +432,7 @@
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PKHUD.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxAtomic.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxCocoa.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxSwift.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftyJSON.framework",
@@ -534,6 +546,7 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
@@ -541,6 +554,7 @@
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -591,6 +605,7 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
@@ -598,6 +613,7 @@
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -634,14 +650,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 8T393AQ955;
+				DEVELOPMENT_TEAM = PP64RT7P8Z;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/ResumeARStarter/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.sg.test.ResumeARStarter;
+				PRODUCT_BUNDLE_IDENTIFIER = com.codepattern.ResumeARStarter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 4.0;
@@ -656,14 +672,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 8T393AQ955;
+				DEVELOPMENT_TEAM = PP64RT7P8Z;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/ResumeARStarter/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.sg.test.ResumeARStarter;
+				PRODUCT_BUNDLE_IDENTIFIER = com.codepattern.ResumeARStarter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 4.0;
@@ -678,10 +694,10 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 8T393AQ955;
+				DEVELOPMENT_TEAM = PP64RT7P8Z;
 				INFOPLIST_FILE = ResumeARTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.sg.ResumeARTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.codepattern.ResumeARStarter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -696,10 +712,10 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 8T393AQ955;
+				DEVELOPMENT_TEAM = PP64RT7P8Z;
 				INFOPLIST_FILE = ResumeARTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = com.sg.ResumeARTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.codepattern.ResumeARStarter;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -713,7 +729,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 8T393AQ955;
+				DEVELOPMENT_TEAM = PP64RT7P8Z;
 				INFOPLIST_FILE = ResumeARUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.sg.ResumeARUITests;
@@ -730,7 +746,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 8T393AQ955;
+				DEVELOPMENT_TEAM = PP64RT7P8Z;
 				INFOPLIST_FILE = ResumeARUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.sg.ResumeARUITests;

--- a/ios_swift/ResumeARStarter/AppDelegate.swift
+++ b/ios_swift/ResumeARStarter/AppDelegate.swift
@@ -21,7 +21,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         // {{allInit}}
         // {{applaunchInit}}

--- a/ios_swift/ResumeARStarter/SCNNode+Text.swift
+++ b/ios_swift/ResumeARStarter/SCNNode+Text.swift
@@ -28,7 +28,7 @@ public extension SCNNode {
         let fullName = profile["fullname"].stringValue
         let fullNameBubble = SCNText(string: fullName, extrusionDepth: CGFloat(bubbleDepth))
         fullNameBubble.font = UIFont(name: "Futura", size: 0.10)?.withTraits(traits: .traitBold)
-        fullNameBubble.alignmentMode = kCAAlignmentCenter
+        fullNameBubble.alignmentMode = convertFromCATextLayerAlignmentMode(CATextLayerAlignmentMode.center)
         fullNameBubble.firstMaterial?.diffuse.contents = UIColor.orange
         fullNameBubble.firstMaterial?.specular.contents = UIColor.white
         fullNameBubble.firstMaterial?.isDoubleSided = true
@@ -56,7 +56,7 @@ public extension SCNNode {
         let linkedIn = profile["linkedin"].stringValue
         let linkedInBubble = SCNText(string: linkedIn, extrusionDepth: CGFloat(bubbleDepth))
         linkedInBubble.font = UIFont(name: "Futura", size: 0.10)?.withTraits(traits: .traitBold)
-        linkedInBubble.alignmentMode = kCAAlignmentCenter
+        linkedInBubble.alignmentMode = convertFromCATextLayerAlignmentMode(CATextLayerAlignmentMode.center)
         linkedInBubble.firstMaterial?.diffuse.contents = UIColor.orange
         linkedInBubble.firstMaterial?.specular.contents = UIColor.white
         linkedInBubble.firstMaterial?.isDoubleSided = true
@@ -84,7 +84,7 @@ public extension SCNNode {
         let twitter = profile["twitter"].stringValue
         let twitterBubble = SCNText(string: twitter, extrusionDepth: CGFloat(bubbleDepth))
         twitterBubble.font = UIFont(name: "Futura", size: 0.10)?.withTraits(traits: .traitBold)
-        twitterBubble.alignmentMode = kCAAlignmentCenter
+        twitterBubble.alignmentMode = convertFromCATextLayerAlignmentMode(CATextLayerAlignmentMode.center)
         twitterBubble.firstMaterial?.diffuse.contents = UIColor.orange
         twitterBubble.firstMaterial?.specular.contents = UIColor.white
         twitterBubble.firstMaterial?.isDoubleSided = true
@@ -112,7 +112,7 @@ public extension SCNNode {
         let facebook = profile["facebook"].stringValue
         let fbBubble = SCNText(string: facebook, extrusionDepth: CGFloat(bubbleDepth))
         fbBubble.font = UIFont(name: "Futura", size: 0.10)?.withTraits(traits: .traitBold)
-        fbBubble.alignmentMode = kCAAlignmentCenter
+        fbBubble.alignmentMode = convertFromCATextLayerAlignmentMode(CATextLayerAlignmentMode.center)
         fbBubble.firstMaterial?.diffuse.contents = UIColor.orange
         fbBubble.firstMaterial?.specular.contents = UIColor.white
         fbBubble.firstMaterial?.isDoubleSided = true
@@ -130,7 +130,7 @@ public extension SCNNode {
         let phone = profile["phone"].stringValue
         let phoneBubble = SCNText(string: phone, extrusionDepth: CGFloat(bubbleDepth))
         phoneBubble.font = UIFont(name: "Futura", size: 0.09)?.withTraits(traits: .traitBold)
-        phoneBubble.alignmentMode = kCAAlignmentCenter
+        phoneBubble.alignmentMode = convertFromCATextLayerAlignmentMode(CATextLayerAlignmentMode.center)
         phoneBubble.firstMaterial?.diffuse.contents = UIColor.orange
         phoneBubble.firstMaterial?.specular.contents = UIColor.white
         phoneBubble.firstMaterial?.isDoubleSided = true
@@ -147,7 +147,7 @@ public extension SCNNode {
         let location = profile["location"].stringValue
         let locBubble = SCNText(string: location, extrusionDepth: CGFloat(bubbleDepth))
         locBubble.font = UIFont(name: "Futura", size: 0.10)?.withTraits(traits: .traitBold)
-        locBubble.alignmentMode = kCAAlignmentCenter
+        locBubble.alignmentMode = convertFromCATextLayerAlignmentMode(CATextLayerAlignmentMode.center)
         locBubble.firstMaterial?.diffuse.contents = UIColor.orange
         locBubble.firstMaterial?.specular.contents = UIColor.white
         locBubble.firstMaterial?.isDoubleSided = true
@@ -201,7 +201,7 @@ public extension SCNNode {
         // BUBBLE-TEXT
         let bubble = SCNText(string: text, extrusionDepth: CGFloat(bubbleDepth))
         bubble.font = UIFont(name: "Futura", size: 0.15)?.withTraits(traits: .traitBold)
-        bubble.alignmentMode = kCAAlignmentCenter
+        bubble.alignmentMode = convertFromCATextLayerAlignmentMode(CATextLayerAlignmentMode.center)
         bubble.firstMaterial?.diffuse.contents = UIColor.orange
         bubble.firstMaterial?.specular.contents = UIColor.white
         bubble.firstMaterial?.isDoubleSided = true
@@ -225,7 +225,7 @@ public extension SCNNode {
     func move(_ position: SCNVector3) {
         SCNTransaction.begin()
         SCNTransaction.animationDuration = 0.4
-        SCNTransaction.animationTimingFunction = CAMediaTimingFunction.init(name: kCAMediaTimingFunctionLinear)
+        SCNTransaction.animationTimingFunction = CAMediaTimingFunction.init(name: CAMediaTimingFunctionName.linear)
         self.position = position
         opacity = 1
         SCNTransaction.commit()
@@ -234,7 +234,7 @@ public extension SCNNode {
     func hide() {
         SCNTransaction.begin()
         SCNTransaction.animationDuration = 2.0
-        SCNTransaction.animationTimingFunction = CAMediaTimingFunction.init(name: kCAMediaTimingFunctionLinear)
+        SCNTransaction.animationTimingFunction = CAMediaTimingFunction.init(name: CAMediaTimingFunctionName.linear)
         opacity = 0
         SCNTransaction.commit()
     }
@@ -243,7 +243,7 @@ public extension SCNNode {
         opacity = 0
         SCNTransaction.begin()
         SCNTransaction.animationDuration = 0.4
-        SCNTransaction.animationTimingFunction = CAMediaTimingFunction.init(name: kCAMediaTimingFunctionLinear)
+        SCNTransaction.animationTimingFunction = CAMediaTimingFunction.init(name: CAMediaTimingFunctionName.linear)
         opacity = 1
         SCNTransaction.commit()
     }
@@ -251,8 +251,13 @@ public extension SCNNode {
 
 private extension UIFont {
     // Based on: https://stackoverflow.com/questions/4713236/how-do-i-set-bold-and-italic-on-uilabel-of-iphone-ipad
-    func withTraits(traits: UIFontDescriptorSymbolicTraits...) -> UIFont {
-        let descriptor = self.fontDescriptor.withSymbolicTraits(UIFontDescriptorSymbolicTraits(traits))
+    func withTraits(traits: UIFontDescriptor.SymbolicTraits...) -> UIFont {
+        let descriptor = self.fontDescriptor.withSymbolicTraits(UIFontDescriptor.SymbolicTraits(traits))
         return UIFont(descriptor: descriptor!, size: 0)
     }
+}
+
+// Helper function inserted by Swift 4.2 migrator.
+fileprivate func convertFromCATextLayerAlignmentMode(_ input: CATextLayerAlignmentMode) -> String {
+	return input.rawValue
 }

--- a/ios_swift/ResumeARStarter/ViewController.swift
+++ b/ios_swift/ResumeARStarter/ViewController.swift
@@ -156,29 +156,25 @@ class ViewController: UIViewController, ARSCNViewDelegate {
         // Retrieve plist
         guard let path = Bundle.main.path(forResource: "BMSCredentials", ofType: "plist"),
             let credentials = NSDictionary(contentsOfFile: path) as? [String: AnyObject] else {
+                // Add a meaningful error message here Christian
                 return
         }
 
         // Retrieve Cloudant credentials
         guard let url = credentials["cloudantUrl"] as? String, !url.isEmpty else {
+                // Add a meaningful error message here Christian
                 return
         }
 
         // Set the Watson credentials for Visual Recognition service from the BMSCredentials.plist
         // If using IAM authentication
-        if let apiKey = credentials["visualrecognitionApikey"] as? String {
-
-            // Create service sdks
-            self.visualRecognition = VisualRecognition(version: self.VERSION, apiKey: apiKey)
-
-        // Else for legacy api_key authentication
-        } else {
-            guard let apiKey = credentials["visualrecognitionApi_key"] as? String else {
-              return
-            }
-            // Create service sdks
-            self.visualRecognition = VisualRecognition.init(version: self.VERSION, apiKey: apiKey)
+        guard let apiKey = credentials["visualrecognitionApikey"] as? String else {
+            // Add Meaningful message here Christian
+            return
         }
+        
+        // Create service sdks
+        self.visualRecognition = VisualRecognition(version: self.VERSION, apiKey: apiKey)
 
         self.cloudantRestCall = CloudantRESTCall.init(cloudantUrl: url)
         self.cloudantRestCall?.database = Constant.databaseName
@@ -449,7 +445,7 @@ class ViewController: UIViewController, ARSCNViewDelegate {
             }
             return
         }
-        
+
         // Update existent face
         DispatchQueue.main.async {
 

--- a/ios_swift/ResumeARStarter/ViewController.swift
+++ b/ios_swift/ResumeARStarter/ViewController.swift
@@ -156,23 +156,23 @@ class ViewController: UIViewController, ARSCNViewDelegate {
         // Retrieve plist
         guard let path = Bundle.main.path(forResource: "BMSCredentials", ofType: "plist"),
             let credentials = NSDictionary(contentsOfFile: path) as? [String: AnyObject] else {
-                // Add a meaningful error message here Christian
+                print("Cannot retrieve 'BMSCredentials.plist' file")
                 return
         }
 
         // Retrieve Cloudant credentials
         guard let url = credentials["cloudantUrl"] as? String, !url.isEmpty else {
-                // Add a meaningful error message here Christian
+                print("Cannot retrieve 'cloudantURL' from 'BMSCredentials.plist'")
                 return
         }
 
         // Set the Watson credentials for Visual Recognition service from the BMSCredentials.plist
         // If using IAM authentication
         guard let apiKey = credentials["visualrecognitionApikey"] as? String else {
-            // Add Meaningful message here Christian
+            print("Cannot retrieve 'visualrecognitionApikey' from 'BMSCredentials.plist'")
             return
         }
-        
+
         // Create service sdks
         self.visualRecognition = VisualRecognition(version: self.VERSION, apiKey: apiKey)
 

--- a/ios_swift/ResumeARStarter/ViewController.swift
+++ b/ios_swift/ResumeARStarter/ViewController.swift
@@ -46,7 +46,7 @@ class ViewController: UIViewController, ARSCNViewDelegate {
         // Register observer
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(didBecomeActive),
-                                               name: .UIApplicationDidBecomeActive,
+                                               name: UIApplication.didBecomeActiveNotification,
                                                object: nil)
         // Set the view's delegate
         sceneView.delegate = self


### PR DESCRIPTION
This PR addresses some problems with the project.

- When upgrading to the Watson 1.0 SDK, RestKit was added as its own framework - this adds it automatically to the `.xcproj`
- Cleaning of log/print statements
- Swift 4.2 conversion