### PR TITLE
Watson SDK via Cocoapods

### DIFF
--- a/README-cn.md
+++ b/README-cn.md
@@ -43,9 +43,9 @@ git clone https://github.com/IBM/ar-resume-with-visual-recognition
 2. 登录到 [IBM Cloud](https://cloud.ibm.com) 帐户，创建 [Watson Visual Recognition](https://cloud.ibm.com/catalog/services/visual-recognition) 服务。创建一系列的凭证并识别 API 密钥。
 
 3. 加载应用时，将为以下每个 zip 文件创建 3 个分类器：[`ResumeAR/sanjeev.zip`](ResumeAR/sanjeev.zip)、 [`ResumeAR/steve.zip`](ResumeAR/steve.zip) 和 [`ResumeAR/scott.zip`](ResumeAR/scott.zip)。
-> 使用 [Watson Visual Recognition 工具](https://watson-visual-recognition.ng.bluemix.net/)创建新的分类器。分类器将训练视觉识别服务，它将能够识别同一个人的多张不同图像。这需要至少使用十张大头照，同时通过使用不是自己的大头照来创建反面数据集训练。
+> 使用 [Watson Visual Recognition 工具](https://cloud.ibm.com/catalog/services/visual-recognition)创建新的分类器。分类器将训练视觉识别服务，它将能够识别同一个人的多张不同图像。这需要至少使用十张大头照，同时通过使用不是自己的大头照来创建反面数据集训练。
 
-4. 创建 [IBM Cloudant 非关系型数据库](https://cloud.ibm.com/catalog/services/cloudant-nosql-db)并保存凭证。该数据库中的每个 JSON 文档都表示**一个**人。可在 [`schema.json`](ResumeAR/schema.json) 中找到 JSON 模式。加载应用时，也会为第 3 步中完成的 3 个分类创建 3 个文档。 
+4. 创建 [IBM Cloudant 非关系型数据库](https://cloud.ibm.com/catalog/services/cloudant-nosql-db)并保存凭证。该数据库中的每个 JSON 文档都表示**一个**人。可在 [`schema.json`](ResumeAR/schema.json) 中找到 JSON 模式。加载应用时，也会为第 3 步中完成的 3 个分类创建 3 个文档。
 > 要在同一数据库中创建新文档，请使用提供的 [`schema.json`](ResumeAR/schema.json) 来填充详细信息。Watson Visual Recognition 模型训练成功之后，使用从分类器收到的 `classificationId` 替换该模式中的 `classificationId`。此 ID 将用于检索有关经过分类的个人的详细信息。
 
 5. 转至 `ios_swift` 目录并使用 `Xcode` 打开项目。
@@ -59,16 +59,14 @@ git clone https://github.com/IBM/ar-resume-with-visual-recognition
 	<key>visualrecognitionApi_key</key>
 	<string>VR_API_KEY</string>
 	<key>cloudantUrl</key>
-	<string>CLOUDANT_URL</string>	
+	<string>CLOUDANT_URL</string>
 </dict>
 </plist>
 ```
 
 7. 在命令行中，运行 `pod install` 以安装依赖项。![Pod 安装输出](images/pod-install-output.png)
 
-8. 运行 `carthage bootstrap --platform iOS` 以安装 Watson 相关依赖项。![Carthage 安装输出](images/carthage-output.png)
-
-9. 完成前面的步骤后，返回到 Xcode，通过单击 `Build` 和 `Run` 菜单选项来运行应用。![Xcode 构建和运行](images/build-and-run.png)
+8. 完成前面的步骤后，返回到 Xcode，通过单击 `Build` 和 `Run` 菜单选项来运行应用。![Xcode 构建和运行](images/build-and-run.png)
 
 注意：Watson Visual Recognition 中的训练可能需要几分钟时间。如果状态为 `training`，那么 AR 将在您的 AR 视图中显示 `Training in progress`。您可以通过使用以下 curl 命令来检查分类器的状态：
 
@@ -78,13 +76,13 @@ curl "https://gateway-a.watsonplatform.net/visual-recognition/api/v3/classifiers
 
 使用 Watson Visual Recognition API 密钥替换 `API_KEY`。
 
-10. 要进行测试，您可以使用 [`images/TestImages`](images/TestImages) 文件夹中提供的测试图像。
+9. 要进行测试，您可以使用 [`images/TestImages`](images/TestImages) 文件夹中提供的测试图像。
 
 # 添加到数据库
 
-要在数据库中创建新的条目，请执行以下步骤： 
+要在数据库中创建新的条目，请执行以下步骤：
 
-1. 使用[联机工具](https://watson-visual-recognition.ng.bluemix.net/)为希望能够识别的每个人创建新的 Watson Visual Recognition 分类器，使用至少十张此人的图像。
+1. 使用[联机工具](https://cloud.ibm.com/catalog/services/visual-recognition)为希望能够识别的每个人创建新的 Watson Visual Recognition 分类器，使用至少十张此人的图像。
 
 2. 使用从前一步获得的分类器 ID 更新 Cloudant 数据库。要更新该数据库，请如下所示执行 `POST` 命令：
 
@@ -123,7 +121,7 @@ curl -H "Content-Type: application/json" -X POST -d $data https://$ACCOUNT.cloud
 * [ARKit](https://developer.apple.com/arkit)
 * [Watson Swift SDK](https://github.com/watson-developer-cloud/swift-sdk)
 * [IBM 视觉识别](https://www.ibm.com/watson/services/visual-recognition-4)
-* [IBM Cloudant](https://www.ibm.com/cloud/cloudant) 
+* [IBM Cloudant](https://www.ibm.com/cloud/cloudant)
 
 # 许可
 

--- a/README.md
+++ b/README.md
@@ -70,13 +70,10 @@ git clone https://github.com/IBM/ar-resume-with-visual-recognition
 </plist>
 ```
 
-7. At a command line, run `pod install` to install the dependencies.
+7. At a command line, run `pod install` to install the [Watson SDK](https://github.com/watson-developer-cloud/swift-sdk#watson-developer-cloud-swift-sdk) and other dependencies.
 ![Pod Install Output](images/pod-install-output.png)
 
-8. Run `carthage bootstrap --platform iOS` to install the Watson related dependencies.
-![Carthage Install Output](images/carthage-output.png)
-
-9. Once the previous steps are complete go back to Xcode and run the application by clicking the `Build` and `Run` menu options.
+8. Once the previous steps are complete go back to Xcode and run the application by clicking the `Build` and `Run` menu options.
 ![Xcode Build and Run](images/build-and-run.png)
 
 NOTE: The training in Watson Visual Recognition might take couple of minutes. If the status is in `training`, then the AR will show `Training in progress` in your AR view. You can check the status of your classifier by using following curl command:
@@ -87,7 +84,7 @@ curl "https://gateway-a.watsonplatform.net/visual-recognition/api/v3/classifiers
 
 Replace the `API_KEY` with the Watson Visual Recognition api key.
 
-10. To test you can use the test images provided in [`images/TestImages`](images/TestImages) folder.
+9. To test you can use the test images provided in [`images/TestImages`](images/TestImages) folder.
 
 # Adding to the database
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ git clone https://github.com/IBM/ar-resume-with-visual-recognition
 2. Log into [IBM Cloud](https://cloud.ibm.com) account and create a [Watson Visual Recognition](https://cloud.ibm.com/catalog/services/visual-recognition) service. Create a set of credentials and identify your API key.
 
 3. When the app loads, it also loads 3 Core ML models which is bundled part of the app. The models were trained using IBM Watson Visual Recognition Tool and downloaded as Core ML model.
-> To create a new classifier use the [Watson Visual Recognition tool](https://watson-visual-recognition.ng.bluemix.net/). A classifier will train the visual recognition service, it will be able to recognize different images of the same person. Use at least ten images of your head shot and also create a negative data set by using headshots that are not your own.
+> To create a new classifier use the [Watson Visual Recognition tool](https://cloud.ibm.com/catalog/services/visual-recognition). A classifier will train the visual recognition service, it will be able to recognize different images of the same person. Use at least ten images of your head shot and also create a negative data set by using headshots that are not your own.
 
 4. Create an [IBM Cloudant NoSQL database](https://cloud.ibm.com/catalog/services/cloudant) and save the credentials. Each JSON document in this database represents **one** person. The JSON schema can be found in [`schema.json`](schema.json). When the app loads, it will also create 3 documents for the 3 CoreML models which is bundled part of the app as mentioned in step 3.
 > To create new documents in the same database, use the [`schema.json`](schema.json) provided to fill out the details. Replace the `classificationId` in the schema with the `classificationId` you receive from the classifier once the Watson Visual Recognition model has been successfully trained. This ID will be used to retrieve details about the classified person.
@@ -93,7 +93,7 @@ Replace the `API_KEY` with the Watson Visual Recognition api key.
 
 To create a new entry in the database perform the following steps:
 
-1. Create a new Watson Visual Recognition classifier using the [online tool](https://watson-visual-recognition.ng.bluemix.net/) for each person you want to be able to identify, use at least ten images of that person.
+1. Create a new Watson Visual Recognition classifier using the [online tool](https://cloud.ibm.com/catalog/services/visual-recognition) for each person you want to be able to identify, use at least ten images of that person.
 
 2. Update the Cloudant database using the classifier ID from the previous step. To update the database perform a `POST` command like the following:
 

--- a/ios_swift/Cartfile
+++ b/ios_swift/Cartfile
@@ -1,1 +1,0 @@
-github "watson-developer-cloud/swift-sdk" ~> 1.1

--- a/ios_swift/Podfile
+++ b/ios_swift/Podfile
@@ -7,10 +7,11 @@ target 'ResumeARStarter' do
   # Pods for ResumeARStarter
 
     pod 'RxSwift',    '~> 4.0'
-    pod 'RxCocoa',    '~> 4.0'    
+    pod 'RxCocoa',    '~> 4.0'
     pod 'SwiftyJSON'
     pod 'PKHUD',      '~> 5.0'
-    
+    pod 'IBMWatsonVisualRecognitionV3', '~> 1.3.1'
+
     post_install do |installer|
         installer.pods_project.targets.each do |target|
             if ['SwiftCloudant'].include? target.name

--- a/ios_swift/README.md
+++ b/ios_swift/README.md
@@ -74,7 +74,7 @@ $ sudo gem install cocoapods
 $ pod setup
 ```
 
-3. At a command line, run `pod install` to install the dependencies.
+3. At a command line, run `pod install` to install the [Watson SDK](https://github.com/watson-developer-cloud/swift-sdk#watson-developer-cloud-swift-sdk) and other dependencies.
 ![Pod Install Output](../images/pod-install-output.png)
 
 If you run into any issues during the pod install, it is recommended to run a pod update by using the following commands:
@@ -83,19 +83,16 @@ $ pod update
 $ pod install
 ```
 
-4. Run `carthage bootstrap --platform iOS` to install the Watson related dependencies.
-![Carthage Install Output](../images/carthage-output.png)
-
-5. Once the previous steps are complete, open the Xcode workspace: `{APP_Name}.xcworkspace`. Run the application by clicking the `Build` and `Run` menu options, specifying the native iOS device on which you will be running the application.
+4. Once the previous steps are complete, open the Xcode workspace: `{APP_Name}.xcworkspace`. Run the application by clicking the `Build` and `Run` menu options, specifying the native iOS device on which you will be running the application.
 ![Xcode Build and Run](../images/build-and-run.png)
 
 #### Classification
 
-When the app loads, the app will create 3 classifiers for each of the zip files [`ResumeAR/sanjeev.zip`](ResumeAR/sanjeev.zip), [`ResumeAR/steve.zip`](ResumeAR/steve.zip) and [`ResumeAR/scott.zip`](ResumeAR/scott.zip).
-> To create a new classifier use the [Watson Visual Recognition tool](https://watson-visual-recognition.ng.bluemix.net/). A classifier will train the visual recognition service, it will be able to recognize different images of the same person. Use at least ten images of your head shot and also create a negative data set by using headshots that are not your own.
+By default, the app comes with 3 classifiers that are put onto the device to classify faces right away.
+> To create a new classifier use the [Watson Visual Recognition tool](https://cloud.ibm.com/catalog/services/visual-recognition). A classifier will train the visual recognition service, it will be able to recognize different images of the same person. Use at least ten images of your head shot and also create a negative data set by using headshots that are not your own.
 
-The app will also create an [IBM Cloudant NoSQL database](https://cloud.ibm.com/catalog/services/cloudant-nosql-db) in the service instance referenced in the `BMSCredentials.plist` file. Each JSON document in this database represents **one** person. The JSON schema can be found in [`schema.json`](ResumeAR/schema.json). When the app loads, it will also create 3 documents for the 3 classification done in step 3.
-> To create new documents in the same database, use the [`schema.json`](ResumeAR/schema.json) provided to fill out the details. Replace the `classificationId` in the schema with the `classificationId` you receive from the classifier once the Watson Visual Recognition model has been successfully trained. This ID will be used to retrieve details about the classified person.
+The app will also create an [IBM Cloudant NoSQL database](https://cloud.ibm.com/catalog/services/cloudant-nosql-db) in the service instance referenced in the `BMSCredentials.plist` file. Each JSON document in this database represents **one** person. The JSON schema can be found in [`schema.json`](./schema.json). When the app loads, it will also create 3 documents for the 3 classification done in step 3.
+> To create new documents in the same database, use the [`schema.json`](./schema.json) provided to fill out the details. Replace the `classificationId` in the schema with the `classificationId` you receive from the classifier once the Watson Visual Recognition model has been successfully trained. This ID will be used to retrieve details about the classified person.
 
 **NOTE:** The training in Watson Visual Recognition might take couple of minutes. If the status is in `training`, then the AR will show `Training in progress` in your AR view. You can check the status of your classifier by using following curl command:
 
@@ -107,7 +104,7 @@ Replace the `API_KEY` with the Watson Visual Recognition api key, as found in yo
 
 ### Run
 
-1. To test the running application on the iPhone, you can use the test images provided in [`Test Images`](../images/TestImages) folder, which will yield the output shown below.
+1. To test the running application on the iPhone, you can use the test images provided in [`Test Images`](https://github.com/IBM/ar-resume-with-visual-recognition/tree/master/images/TestImages) folder, which will yield the output shown below.
 
 #### Sample Output
 
@@ -119,7 +116,7 @@ Replace the `API_KEY` with the Watson Visual Recognition api key, as found in yo
 
 To create a new classifier and database entry, perform the following steps:
 
-1. Create a new Watson Visual Recognition classifier using the [online tool](https://watson-visual-recognition.ng.bluemix.net/) for each person you want to be able to identify, use at least ten images of that person.
+1. Create a new Watson Visual Recognition classifier using the [online tool](https://cloud.ibm.com/catalog/services/visual-recognition) for each person you want to be able to identify, use at least ten images of that person.
 
 2. Update the Cloudant database using the classifier ID from the previous step. To update the database perform a `POST` command like the following:
 
@@ -133,7 +130,7 @@ curl -H "Content-Type: application/json" -X POST -d $data https://$ACCOUNT.cloud
 
 > The `$DATABASE` variable is the database name you created in IBM Cloudant.
 
-> See [`ResumeAR/schema.json`](ResumeAR/schema.json) for additional information about the Cloudant database configuration.
+> See [`schema.json`](./schema.json) for additional information about the Cloudant database configuration.
 
 3. Run the app and point the camera view to your newly classified image.
 

--- a/ios_swift/ResumeARStarter.xcodeproj/project.pbxproj
+++ b/ios_swift/ResumeARStarter.xcodeproj/project.pbxproj
@@ -9,10 +9,7 @@
 /* Begin PBXBuildFile section */
 		3842A74647F25DB5BCED9FBB /* Pods_ResumeARStarterUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE1F8E97AE6145B021ACA986 /* Pods_ResumeARStarterUITests.framework */; };
 		A17C9566A3740B96AF43E648 /* Pods_ResumeARStarterTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7982E6C28D22700E9D94651E /* Pods_ResumeARStarterTests.framework */; };
-		AA27243821E93A90005B7878 /* RestKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA27243721E93A90005B7878 /* RestKit.framework */; };
-		AA27243921E93A90005B7878 /* RestKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = AA27243721E93A90005B7878 /* RestKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		AA27243B21E93E0B005B7878 /* BMSCredentials.plist in Resources */ = {isa = PBXBuildFile; fileRef = AA27243A21E93E0B005B7878 /* BMSCredentials.plist */; };
-		B424BCFA201F92DA00B18120 /* Cartfile in Resources */ = {isa = PBXBuildFile; fileRef = B424BCF9201F92DA00B18120 /* Cartfile */; };
 		B430E1231FE8448A00058C99 /* CloudantRESTCall.swift in Sources */ = {isa = PBXBuildFile; fileRef = B430E1221FE8448A00058C99 /* CloudantRESTCall.swift */; };
 		B43158AA209BA0BB004A0BF4 /* ScottDAngelo_1040670748.mlmodel in Sources */ = {isa = PBXBuildFile; fileRef = B43158A7209BA0BB004A0BF4 /* ScottDAngelo_1040670748.mlmodel */; };
 		B43158AB209BA0BB004A0BF4 /* SanjeevGhimire_967590069.mlmodel in Sources */ = {isa = PBXBuildFile; fileRef = B43158A8209BA0BB004A0BF4 /* SanjeevGhimire_967590069.mlmodel */; };
@@ -26,8 +23,6 @@
 		B479E75E2064616800786B47 /* Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = B479E75D2064616800786B47 /* Constant.swift */; };
 		B479E7622064643600786B47 /* Podfile in Resources */ = {isa = PBXBuildFile; fileRef = B479E7612064643600786B47 /* Podfile */; };
 		B4B2E7961FCDDF4E006DDB9D /* SCNNode+Text.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4B2E7951FCDDF4E006DDB9D /* SCNNode+Text.swift */; };
-		B4BE3DAE1FDB186C00268324 /* VisualRecognitionV3.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B4BE3DAC1FDB185900268324 /* VisualRecognitionV3.framework */; };
-		B4BE3DAF1FDB186C00268324 /* VisualRecognitionV3.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B4BE3DAC1FDB185900268324 /* VisualRecognitionV3.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B4BF235F1FA2745D002906DD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4BF235E1FA2745D002906DD /* AppDelegate.swift */; };
 		B4BF23611FA2745D002906DD /* art.scnassets in Resources */ = {isa = PBXBuildFile; fileRef = B4BF23601FA2745D002906DD /* art.scnassets */; };
 		B4BF23631FA2745D002906DD /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4BF23621FA2745D002906DD /* ViewController.swift */; };
@@ -56,21 +51,6 @@
 		};
 /* End PBXContainerItemProxy section */
 
-/* Begin PBXCopyFilesBuildPhase section */
-		B4B2E7941FB6203A006DDB9D /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				B4BE3DAF1FDB186C00268324 /* VisualRecognitionV3.framework in Embed Frameworks */,
-				AA27243921E93A90005B7878 /* RestKit.framework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
-
 /* Begin PBXFileReference section */
 		0D32300355843067E35F0C22 /* Pods-ResumeARStarter.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ResumeARStarter.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ResumeARStarter/Pods-ResumeARStarter.debug.xcconfig"; sourceTree = "<group>"; };
 		4D198001CBDD4375574674E5 /* Pods-ResumeARStarter.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ResumeARStarter.release.xcconfig"; path = "Pods/Target Support Files/Pods-ResumeARStarter/Pods-ResumeARStarter.release.xcconfig"; sourceTree = "<group>"; };
@@ -78,10 +58,8 @@
 		6B562D0F95F07D1705DB003A /* Pods-ResumeARStarterTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ResumeARStarterTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-ResumeARStarterTests/Pods-ResumeARStarterTests.release.xcconfig"; sourceTree = "<group>"; };
 		7735D50469CCC5D6A4C37810 /* Pods-ResumeARStarterTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ResumeARStarterTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ResumeARStarterTests/Pods-ResumeARStarterTests.debug.xcconfig"; sourceTree = "<group>"; };
 		7982E6C28D22700E9D94651E /* Pods_ResumeARStarterTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ResumeARStarterTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		AA27243721E93A90005B7878 /* RestKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RestKit.framework; path = Carthage/Build/iOS/RestKit.framework; sourceTree = "<group>"; };
 		AA27243A21E93E0B005B7878 /* BMSCredentials.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = BMSCredentials.plist; sourceTree = "<group>"; };
 		AE1F8E97AE6145B021ACA986 /* Pods_ResumeARStarterUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ResumeARStarterUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		B424BCF9201F92DA00B18120 /* Cartfile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Cartfile; sourceTree = "<group>"; };
 		B430E1221FE8448A00058C99 /* CloudantRESTCall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudantRESTCall.swift; sourceTree = "<group>"; };
 		B43158A7209BA0BB004A0BF4 /* ScottDAngelo_1040670748.mlmodel */ = {isa = PBXFileReference; lastKnownFileType = file.mlmodel; path = ScottDAngelo_1040670748.mlmodel; sourceTree = "<group>"; };
 		B43158A8209BA0BB004A0BF4 /* SanjeevGhimire_967590069.mlmodel */ = {isa = PBXFileReference; lastKnownFileType = file.mlmodel; path = SanjeevGhimire_967590069.mlmodel; sourceTree = "<group>"; };
@@ -95,7 +73,6 @@
 		B479E75D2064616800786B47 /* Constant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constant.swift; sourceTree = "<group>"; };
 		B479E7612064643600786B47 /* Podfile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Podfile; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		B4B2E7951FCDDF4E006DDB9D /* SCNNode+Text.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SCNNode+Text.swift"; sourceTree = "<group>"; };
-		B4BE3DAC1FDB185900268324 /* VisualRecognitionV3.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = VisualRecognitionV3.framework; path = Carthage/Build/iOS/VisualRecognitionV3.framework; sourceTree = "<group>"; };
 		B4BF235B1FA2745D002906DD /* ResumeARStarter.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ResumeARStarter.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B4BF235E1FA2745D002906DD /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		B4BF23601FA2745D002906DD /* art.scnassets */ = {isa = PBXFileReference; lastKnownFileType = wrapper.scnassets; path = art.scnassets; sourceTree = "<group>"; };
@@ -119,9 +96,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B4BE3DAE1FDB186C00268324 /* VisualRecognitionV3.framework in Frameworks */,
 				D77DFA937B3DBE328F4F3D53 /* Pods_ResumeARStarter.framework in Frameworks */,
-				AA27243821E93A90005B7878 /* RestKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -160,7 +135,6 @@
 		4181389323BBC2B8BAEDDAC8 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				B4BE3DAC1FDB185900268324 /* VisualRecognitionV3.framework */,
 				6455BE3FA1A3CA353B5C036C /* Pods_ResumeARStarter.framework */,
 				7982E6C28D22700E9D94651E /* Pods_ResumeARStarterTests.framework */,
 				AE1F8E97AE6145B021ACA986 /* Pods_ResumeARStarterUITests.framework */,
@@ -171,9 +145,7 @@
 		B4BF23521FA2745C002906DD = {
 			isa = PBXGroup;
 			children = (
-				AA27243721E93A90005B7878 /* RestKit.framework */,
 				B479E7612064643600786B47 /* Podfile */,
-				B424BCF9201F92DA00B18120 /* Cartfile */,
 				B4BF235D1FA2745D002906DD /* ResumeARStarter */,
 				B4BF23741FA2745D002906DD /* ResumeARStarterTests */,
 				B4BF237F1FA2745D002906DD /* ResumeARStarterUITests */,
@@ -250,7 +222,6 @@
 				B4BF23581FA2745D002906DD /* Frameworks */,
 				B4BF23591FA2745D002906DD /* Resources */,
 				C7C5CDDBE3D48F0EA7C3C56E /* [CP] Embed Pods Frameworks */,
-				B4B2E7941FB6203A006DDB9D /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -312,7 +283,7 @@
 					B4BF235A1FA2745D002906DD = {
 						CreatedOnToolsVersion = 9.0.1;
 						LastSwiftMigration = 1010;
-						ProvisioningStyle = Automatic;
+						ProvisioningStyle = Manual;
 					};
 					B4BF23701FA2745D002906DD = {
 						CreatedOnToolsVersion = 9.0.1;
@@ -353,7 +324,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B424BCFA201F92DA00B18120 /* Cartfile in Resources */,
 				B479E7542059A3C300786B47 /* twitter.png in Resources */,
 				B4BF23611FA2745D002906DD /* art.scnassets in Resources */,
 				B4BF236B1FA2745D002906DD /* LaunchScreen.storyboard in Resources */,
@@ -426,6 +396,8 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-ResumeARStarter/Pods-ResumeARStarter-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/IBMWatsonRestKit/RestKit.framework",
+				"${BUILT_PRODUCTS_DIR}/IBMWatsonVisualRecognitionV3/VisualRecognition.framework",
 				"${BUILT_PRODUCTS_DIR}/PKHUD/PKHUD.framework",
 				"${BUILT_PRODUCTS_DIR}/RxAtomic/RxAtomic.framework",
 				"${BUILT_PRODUCTS_DIR}/RxCocoa/RxCocoa.framework",
@@ -434,6 +406,8 @@
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RestKit.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/VisualRecognition.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PKHUD.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxAtomic.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxCocoa.framework",
@@ -651,13 +625,11 @@
 			baseConfigurationReference = 0D32300355843067E35F0C22 /* Pods-ResumeARStarter.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = PP64RT7P8Z;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "$(SRCROOT)/ResumeARStarter/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.codepattern.ResumeARStarter;
@@ -673,13 +645,11 @@
 			baseConfigurationReference = 4D198001CBDD4375574674E5 /* Pods-ResumeARStarter.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = PP64RT7P8Z;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "$(SRCROOT)/ResumeARStarter/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.codepattern.ResumeARStarter;

--- a/ios_swift/ResumeARStarter/ViewController.swift
+++ b/ios_swift/ResumeARStarter/ViewController.swift
@@ -19,7 +19,7 @@ import Vision
 import RxSwift
 import RxCocoa
 import SwiftyJSON
-import VisualRecognitionV3
+import VisualRecognition
 import PKHUD
 import CoreML
 // {{allIncludes}}


### PR DESCRIPTION
This PR changes the project from using Carthage to Cocoapods for installing the Watson SDK.  This makes the starterkit consistent with the rest of the Apple Console which has made the switch, and simplifies the installation process.

The corresponding blog post should be updated @stevemart.