### PR TITLE
increased timing of each classification request

### DIFF
--- a/ios_swift/ResumeARStarter/ViewController.swift
+++ b/ios_swift/ResumeARStarter/ViewController.swift
@@ -189,7 +189,7 @@ class ViewController: UIViewController, ARSCNViewDelegate {
         // Run the view's session
         sceneView.session.run(configuration)
 
-        Observable<Int>.interval(0.6, scheduler: SerialDispatchQueueScheduler(qos: .default))
+        Observable<Int>.interval(3, scheduler: SerialDispatchQueueScheduler(qos: .default))
             .subscribeOn(SerialDispatchQueueScheduler(qos: .background))
             .flatMap {_ in self.updateToLocalModels()}
             .flatMap {_ in self.faceObservation() }
@@ -203,7 +203,7 @@ class ViewController: UIViewController, ARSCNViewDelegate {
                 self.updateNode(classes: element.classes, position: element.position, frame: element.frame)
             }.disposed(by: 👜)
 
-        Observable<Int>.interval(0.6, scheduler: SerialDispatchQueueScheduler(qos: .default))
+        Observable<Int>.interval(3, scheduler: SerialDispatchQueueScheduler(qos: .default))
             .subscribeOn(SerialDispatchQueueScheduler(qos: .background))
             .subscribe { [unowned self] _ in
 


### PR DESCRIPTION
* increased the observable interval time to allow threads to start and perish before next thread appear for classification